### PR TITLE
feat: add `DeploymentConfig` for network specifc deployments

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -3,9 +3,11 @@ pragma solidity >=0.8.19 <=0.9.0;
 
 import { Foo } from "../src/Foo.sol";
 import { BaseScript } from "./Base.s.sol";
+import { DeploymentConfig } from "./DeploymentConfig.s.sol";
 
 contract Deploy is BaseScript {
-    function run() public broadcast returns (Foo foo) {
+    function run() public returns (Foo foo, DeploymentConfig deploymentConfig) {
+        deploymentConfig = new DeploymentConfig(broadcaster);
         foo = new Foo();
     }
 }

--- a/script/DeploymentConfig.s.sol
+++ b/script/DeploymentConfig.s.sol
@@ -1,0 +1,39 @@
+//// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity >=0.8.19 <=0.9.0;
+
+import { Script } from "forge-std/Script.sol";
+
+contract DeploymentConfig is Script {
+    error DeploymentConfig_InvalidDeployerAddress();
+    error DeploymentConfig_NoConfigForChain(uint256);
+
+    struct NetworkConfig {
+        address deployer;
+    }
+
+    NetworkConfig public activeNetworkConfig;
+
+    address private deployer;
+
+    constructor(address _broadcaster) {
+        if (block.chainid == 31_337) {
+            activeNetworkConfig = getOrCreateAnvilEthConfig();
+        } else {
+            revert DeploymentConfig_NoConfigForChain(block.chainid);
+        }
+        if (_broadcaster == address(0)) revert DeploymentConfig_InvalidDeployerAddress();
+        deployer = _broadcaster;
+    }
+
+    function getOrCreateAnvilEthConfig() public view returns (NetworkConfig memory) {
+        return NetworkConfig({ deployer: deployer });
+    }
+
+    // This function is a hack to have it excluded by `forge coverage` until
+    // https://github.com/foundry-rs/foundry/issues/2988 is fixed.
+    // See: https://github.com/foundry-rs/foundry/issues/2988#issuecomment-1437784542
+    // for more info.
+    // solhint-disable-next-line
+    function test() public { }
+}

--- a/test/Foo.t.sol
+++ b/test/Foo.t.sol
@@ -3,13 +3,19 @@ pragma solidity >=0.8.19 <0.9.0;
 
 import { Test, console } from "forge-std/Test.sol";
 
+import { Deploy } from "../script/Deploy.s.sol";
+import { DeploymentConfig } from "../script/DeploymentConfig.s.sol";
 import { Foo } from "../src/Foo.sol";
 
 contract FooTest is Test {
     Foo internal foo;
+    DeploymentConfig internal deploymentConfig;
+
+    address internal deployer;
 
     function setUp() public virtual {
-        foo = new Foo();
+        Deploy deployment = new Deploy();
+        (foo, deploymentConfig) = deployment.run();
     }
 
     function test_Example() external {


### PR DESCRIPTION

## Description

To allow deployment to different chains but using the same deployment scripts, this commit introduces a basic `DeploymentConfig` which can be extended as necessary in each project.

There's a few things that should be considered:

- `activeNetworkConfig` will be initialized via the constructor, at which point it is know what `block.chainid` is
- To add new configuration settings, extend `NetworkConfig`
- To add a new config for a different chain, extend the `if/else` block in the constructor so that it creates a `NetworkConfig` for the chain in question


## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [x] Ran `pnpm lint`?
- [x] Ran `forge test`?
