### PR TITLE
build: add codecov task to CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,28 @@ jobs:
         run: |
           echo "## Tests result" >> $GITHUB_STEP_SUMMARY
           echo "✅ Passed" >> $GITHUB_STEP_SUMMARY
+
+  coverage:
+    needs: ["lint", "build"]
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Check out the repo"
+        uses: "actions/checkout@v3"
+        with:
+          submodules: "recursive"
+
+      - name: "Install Foundry"
+        uses: "foundry-rs/foundry-toolchain@v1"
+
+      - name: "Generate the coverage report using the unit and the integration tests"
+        run: 'forge coverage --match-path "test/**/*.sol" --report lcov'
+
+      - name: "Upload coverage report to Codecov"
+        uses: "codecov/codecov-action@v3"
+        with:
+          files: "./lcov.info"
+
+      - name: "Add coverage summary"
+        run: |
+          echo "## Coverage result" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Uploaded to Codecov" >> $GITHUB_STEP_SUMMARY

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,28 @@
+codecov:
+  require_ci_to_pass: false
+comment: false
+ignore:
+  - "script"
+  - "test"
+coverage:
+  status:
+    project:
+      default:
+        # advanced settings
+
+        # Prevents PR from being blocked with a reduction in coverage.
+        # Note, if we want to re-enable this, a `threshold` value can be used
+        # allow coverage to drop by x% while still posting a success status.
+        # `informational`: https://docs.codecov.com/docs/commit-status#informational
+        # `threshold`: https://docs.codecov.com/docs/commit-status#threshold
+        informational: true
+    patch:
+      default:
+        # advanced settings
+
+        # Prevents PR from being blocked with a reduction in coverage.
+        # Note, if we want to re-enable this, a `threshold` value can be used
+        # allow coverage to drop by x% while still posting a success status.
+        # `informational`: https://docs.codecov.com/docs/commit-status#informational
+        # `threshold`: https://docs.codecov.com/docs/commit-status#threshold
+        informational: true


### PR DESCRIPTION
## Description

This adds a new CI action to get code coverage analysis.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [x] Ran `pnpm lint`?
- [ ] Ran `forge test`?
