### PR TITLE
chore: yarn -> pnpm in PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,5 +8,5 @@ Ensure you completed **all of the steps** below before submitting your pull requ
 
 - [ ] Added natspec comments?
 - [ ] Ran `forge snapshot`?
-- [ ] Ran `yarn lint`?
+- [ ] Ran `pnpm lint`?
 - [ ] Ran `forge test`?


### PR DESCRIPTION
## Description

We're using `pnpm` not `yarn`.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [x] Ran `yarn lint`?
- [ ] Ran `forge test`?
