### PR TITLE
chore: trigger add-pr-to-project-board only on opened PRs

### DIFF
--- a/.github/workflows/add-pr-to-project-board.yml
+++ b/.github/workflows/add-pr-to-project-board.yml
@@ -2,6 +2,8 @@ name: Add PR task board
 
 on:
   pull_request:
+    types:
+      - opened
 
 jobs:
   add-to-project:


### PR DESCRIPTION

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `forge snapshot`?
- [x] Ran `pnpm lint`?
- [ ] Ran `forge test`?
- [ ] Ran `pnpm verify`?
