### PR TITLE
Update gas-report command to latest foundry

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint:sol": "forge fmt --check && pnpm solhint {script,src,test,certora}/**/*.sol",
     "prettier:check": "prettier --check **/*.{json,md,yml} --ignore-path=.prettierignore",
     "prettier:write": "prettier --write **/*.{json,md,yml} --ignore-path=.prettierignore",
-    "gas-report": "forge test --gas-report 2>&1 | (tee /dev/tty | awk '/Test result:/ {found=1; buffer=\"\"; next} found && !/Ran/ {buffer=buffer $0 ORS} /Ran/ {found=0} END {printf \"%s\", buffer}' > .gas-report)",
+    "gas-report": "forge test --gas-report 2>&1 | (tee /dev/tty | awk '/Suite result:/ {found=1; buffer=\"\"; next} found && !/Ran/ {buffer=buffer $0 ORS} /Ran/ {found=0} END {printf \"%s\", buffer}' > .gas-report)",
     "release": "commit-and-tag-version",
     "adorno": "pnpm prettier:write && forge fmt && forge snapshot && pnpm gas-report"
   }


### PR DESCRIPTION
Foundry changed the test command output, changing the "Test result" to "Suite result", causing the command gas-report to stop working.  See https://github.com/foundry-rs/foundry/pull/7228 https://github.com/foundry-rs/foundry/commit/17215eb2f7205849ea1c9849fafcb96c3c3a85ea

Updating the word on the gas-report command fixes the problem.

## Description

Describe the changes made in your pull request here.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `pnpm adorno`?
- [ ] Ran `pnpm verify`?
