### PR TITLE
chore(.gitattributes): add merge settings for .gas-report and .gas-sn…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 lib/** linguist-vendored
 
 * text=auto eol=lf
+
+.gas-report merge=ours 
+.gas-snapshot merge=ours


### PR DESCRIPTION
…apshot: merge always everything from merging branch - as this is the real value of current gas costs.

## Description

This change is important because we keep having problems with merging because of those files. This change will make the merge automatic if the conflict is only on this file. The settings define that the merging from branch will overwrite the merged to files .gas-snapshot and .gas-report

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `pnpm adorno`?
- [ ] Ran `pnpm verify`?
