### PR TITLE
chore(package.json): update "gas-report" script to use "forge snapsho…

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "lint:sol": "forge fmt --check && pnpm solhint {script,src,test,certora}/**/*.sol",
     "prettier:check": "prettier --check **/*.{json,md,yml} --ignore-path=.prettierignore",
     "prettier:write": "prettier --write **/*.{json,md,yml} --ignore-path=.prettierignore",
-    "gas-report": "forge test --gas-report 2>&1 | (tee /dev/tty | awk '/Suite result:/ {found=1; buffer=\"\"; next} found && !/Ran/ {buffer=buffer $0 ORS} /Ran/ {found=0} END {printf \"%s\", buffer}' > .gas-report)",
+    "gas-report": "forge snapshot --gas-report 2>&1 | (tee /dev/tty | awk '/Suite result:/ {found=1; buffer=\"\"; next} found && !/Ran/ {buffer=buffer $0 ORS} /Ran/ {found=0} END {printf \"%s\", buffer}' > .gas-report)",
     "release": "commit-and-tag-version",
-    "adorno": "pnpm prettier:write && forge fmt && forge snapshot && pnpm gas-report"
+    "adorno": "pnpm prettier:write && forge fmt && pnpm gas-report"
   }
 }


### PR DESCRIPTION
…t" command and remove double testing in adorno command.

## Description

When adorno command was being run, it would run all the tests twice, making it too slow for large projects. This change ensures the tests run only once, and generate all the report files from a single command. 

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Added natspec comments?
- [x] Ran `pnpm adorno`?
- [x] Ran `pnpm verify`?
