### PR TITLE
chore(githooks): add pre-commit scripts for adorno

### DIFF
--- a/githooks/pre-commit-adorno
+++ b/githooks/pre-commit-adorno
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+foundryup
+
+if [ $? -ne 0 ]; then
+  echo "foundryup failed."
+  exit 1
+fi
+
+pnpm run adorno
+
+if [ $? -ne 0 ]; then
+  echo "pnpm run adorno failed."
+  exit 1
+fi
+
+git add .
+
+echo "Successfully ran pnpm run adorno and added modified files."
+
+exit 0


### PR DESCRIPTION
## Description

I always have this problem on forgetting to send lint to the PR, than the CI will run and fail, and I will have to do --force commits. 
This would automate the process by automatically running commands we have to use before commiting. 
This githook can be enabled by adding a file on .git/hooks folder calling these scripts. 

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `pnpm adorno`?
- [ ] Ran `pnpm verify`?
