### PR TITLE
chore(vscode): update Solidity formatter and package defaults

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,13 @@
 {
   "[solidity]": {
-    "editor.defaultFormatter": "NomicFoundation.hardhat-solidity"
+    "editor.defaultFormatter": "JuanBlanco.solidity"
   },
   "[toml]": {
     "editor.defaultFormatter": "tamasfe.even-better-toml"
   },
   "npm.exclude": "**/lib/**",
+  "solidity.packageDefaultDependenciesContractsDirectory": "src",
+  "solidity.packageDefaultDependenciesDirectory": "lib",
+  "solidity.compileUsingRemoteVersion": "v0.8.19",
   "solidity.formatter": "forge"
 }


### PR DESCRIPTION
## Description

Apply config suggested by foundry in https://book.getfoundry.sh/config/vscode

We actually should discuss if the change of solidity formatter is a good suggestion from the docs.
JuanBlanco.solidity is the most popular, but NomicFoundation.hardhat-solidity seem to integrate better. Just for example, JuanBlanco.solidity does not follow the solc defined in foundry.toml, which made me create this [pre-commit hook script](https://github.com/vacp2p/foundry-template/pull/34/commits/15f2a181183b0fe2468574587fa31b54bda9a68e#diff-b2209cc272af0b8ebf64f399f3d4eb94e3960bcf3b058e2431d5185acd51d655) just to keep it in sync with the project config. 

Related to https://github.com/PaulRBerg/foundry-template/issues/60 
See also https://github.com/juanfranblanco/vscode-solidity/issues/463


We might recosnider the 

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `pnpm adorno`?
- [ ] Ran `pnpm verify`?
