### PR TITLE
chore(githooks): add pre-commit script to sync solc version

### DIFF
--- a/githooks/pre-commit-solc-sync
+++ b/githooks/pre-commit-solc-sync
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Initialize a flag to track if we are in the [profile.default] section
+in_profile_default=false
+
+# Loop through each line of foundry.toml
+while IFS= read -r line
+do
+  # Check if we are entering the [profile.default] section
+  if [[ "$line" =~ ^\[profile\.default\] ]]; then
+    in_profile_default=true
+  fi
+
+  # Check if we find the solc version in the [profile.default] section
+  if $in_profile_default && [[ "$line" =~ solc\ *=\ *\"[0-9]+\.[0-9]+\.[0-9]+\" ]]; then
+    # Extract the version number and trim spaces
+    SOLC_VERSION=$(echo "$line" | sed -E 's/solc *= *"([0-9]+\.[0-9]+\.[0-9]+)"/\1/' | xargs)
+    break
+  fi
+
+  # Stop checking after we leave the [profile.default] section
+  if [[ "$line" =~ ^\[.*\] && ! "$line" =~ ^\[profile\.default\] ]]; then
+    in_profile_default=false
+  fi
+done < foundry.toml
+
+# Check if the version was extracted successfully
+if [ -z "$SOLC_VERSION" ]; then
+  echo "Error: Could not find solc version in foundry.toml"
+  exit 1
+fi
+
+echo "Extracted solc version: $SOLC_VERSION"
+
+# Update the .vscode/settings.json file
+SETTINGS_FILE=".vscode/settings.json"
+
+# Update the .vscode/settings.json file
+SETTINGS_FILE=".vscode/settings.json"
+
+# Create the file if it doesn't exist
+if [ ! -f "$SETTINGS_FILE" ]; then
+  echo '{}' > "$SETTINGS_FILE"
+fi
+
+# Check if the "solidity.compileUsingRemoteVersion" key exists
+if grep -q '"solidity.compileUsingRemoteVersion"' "$SETTINGS_FILE"; then
+  # If the key exists, update the version
+  sed -i -E "s/\"solidity.compileUsingRemoteVersion\": *\"[^\"]*\"/\"solidity.compileUsingRemoteVersion\": \"$SOLC_VERSION\"/" "$SETTINGS_FILE"
+else
+  # Key does not exist, so we modify the last key, add the new one, and close the bracket
+  LAST_KEY=$(tail -n 2 "$SETTINGS_FILE" | head -n 1 | sed 's/,$//') # Remove trailing comma if exists
+  sed -i '$d' "$SETTINGS_FILE" # Remove the last closing brace
+  sed -i '$d' "$SETTINGS_FILE" # Remove the line that will be rewriten
+  # Write the last key back with a comma, add the new key, and close the JSON object
+  echo "$LAST_KEY," >> "$SETTINGS_FILE"
+  echo "  \"solidity.compileUsingRemoteVersion\": \"$SOLC_VERSION\"" >> "$SETTINGS_FILE"
+  echo "}" >> "$SETTINGS_FILE"
+fi
+
+# Add the updated settings.json to the commit
+git add "$SETTINGS_FILE"
+
+echo "Updated .vscode/settings.json with solc version $SOLC_VERSION"
+
+exit 0


### PR DESCRIPTION


## Description

This commit adds a new pre-commit script called "pre-commit-solc-sync" to the githooks directory. The script is responsible for extracting the solc version from the "foundry.toml" file and updating the ".vscode/settings.json" file with the extracted version. If the "solidity.compileUsingRemoteVersion" key already exists in the settings file, the script updates the version. Otherwise, it modifies the last key, adds the new key, and closes the JSON object. Finally, the updated settings file is added to the commit.

The purpose of this change is to automate the synchronization of the solc version used for Solidity compilation in the project everywhere else its also need to be configured configured.

See https://github.com/juanfranblanco/vscode-solidity/issues/463

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Added natspec comments?
- [ ] Ran `pnpm adorno`?
- [ ] Ran `pnpm verify`?
